### PR TITLE
fix username enumeration

### DIFF
--- a/TeamServer/Services/Extra/UserStore.cs
+++ b/TeamServer/Services/Extra/UserStore.cs
@@ -226,7 +226,8 @@ namespace TeamServer.Services.Extra
             {
                 Console.WriteLine(ex.Message);
                 Console.WriteLine(ex.StackTrace);
-                return null;
+                byte[] dummySalt = new byte[32];
+                return dummySalt;
             }
         }
         


### PR DESCRIPTION
Salt lookup occurs by username. Providing an invalid username provides a different error message than if the user is valid due to the GetUserPasswordSalt method returning a null for non-existent users. Fix(?) is returning a dummy salt