### PR TITLE
Update Index.razor

### DIFF
--- a/HardHatC2Client/Pages/Index.razor
+++ b/HardHatC2Client/Pages/Index.razor
@@ -38,7 +38,7 @@
             <!-- add a div for an outline button that is yellow and loads the Engineer page -->
             <div class="container-lg mt-xxl-5 text-center mb-lg-5 pb-lg-5">
                 <button class="btn btn-outline-success btn-lg pt-xl-5 pb-xl-5 px-xl-4 mx-lg-4 shadow-lg" style="display:inline-block" onclick="window.location.href='/Managers'">Create Manager</button>
-                <button class="btn btn-outline-warning btn-lg pt-xl-5 pb-xl-5 px-xl-4 mx-lg-4 shadow-lg" style="display:inline-block" onclick="window.location.href='/Engineers'">Create Engineer</button>	
+                <button class="btn btn-outline-warning btn-lg pt-xl-5 pb-xl-5 px-xl-4 mx-lg-4 shadow-lg" style="display:inline-block" onclick="window.location.href='/Implants'">Create Engineer</button>	
                 <button class="btn btn-outline-primary btn-lg pt-xl-5 pb-xl-5 px-xl-5 mx-lg-4 shadow-lg" style="display:inline-block" onclick="window.location.href='/Interact'">Interact</button>
             </div>
             <br>


### PR DESCRIPTION
`/Engineers` seems no longer to exist therefore I made the button route to `/Implants` instead. Another option is to add another `@page` attribute in `Implants.razor` with the value `/Engineers`. Speaking of which, an alternative syntax to the `@page` attribute is `@attribute [Route("ACTUAL_ROUTE")]`:

```csharp
@page "/Implants"
@attribute [Route("/Engineers")]
```

However, in this case, this might create confusion because the URL will show `/Engineers` while the nav menu shows `Implants`. I leave this to you to decide upon.

---

I just noticed the same issue with `/Interact`, it should be instead `/ImplantInteract`.