### PR TITLE
Moved the theme toggle button to the top nav bar

### DIFF
--- a/HardHatC2Client/Components/AssemblyView.razor
+++ b/HardHatC2Client/Components/AssemblyView.razor
@@ -95,7 +95,7 @@
                 Language = "csharp",
                 Value = ""
             };
-        if (Settings.IsCheckedBox)
+        if (MainLayout.IsDarkMode)
         {
             editorInstance.Theme = "vs-dark";
         }

--- a/HardHatC2Client/Components/AutpParsedCommandTable.razor
+++ b/HardHatC2Client/Components/AutpParsedCommandTable.razor
@@ -8,8 +8,8 @@
 
     </ToolBarContent>
     <HeaderContent>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<string[], string>(x=>x.ElementAt(0))">Name</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<string[], string>(x=>x.ElementAt(1))">Value</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<string[], string>(x=>x.ElementAt(0))">Name</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<string[], string>(x=>x.ElementAt(1))">Value</MudTableSortLabel></MudTh>
     </HeaderContent>
     <RowTemplate>
         <MudTd>@context[0]</MudTd>

--- a/HardHatC2Client/Components/CommandCodeView.razor
+++ b/HardHatC2Client/Components/CommandCodeView.razor
@@ -69,7 +69,7 @@
                 Language = GetCodeLanguage(selectedCodeFile.Key),
                 Value = File.ReadAllText(selectedCodeFile.Value)
             };
-        if (Settings.IsCheckedBox)
+        if (MainLayout.IsDarkMode)
         {
             editorInstance.Theme = "vs-dark";
         }

--- a/HardHatC2Client/Components/CompiledImplantTable.razor
+++ b/HardHatC2Client/Components/CompiledImplantTable.razor
@@ -24,18 +24,18 @@
             <MudTextField @bind-Value="searchString1" Placeholder="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
         </ToolBarContent>
         <HeaderContent>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.Id)">Id</MudTableSortLabel></MudTh>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.ImplantType)">Implant Type</MudTableSortLabel></MudTh>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.Name)">Name</MudTableSortLabel></MudTh>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.ManagerName)">Manager Name</MudTableSortLabel></MudTh>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.CompileDateTime)">Compile DateTime</MudTableSortLabel></MudTh>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.KillDateTime)">KillDateTime</MudTableSortLabel></MudTh>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.ConnectionAttempts)">ConnectionAttempts</MudTableSortLabel></MudTh>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.IncludedCommands)">Included Commands</MudTableSortLabel></MudTh>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.IncludedModules)">Included Modules</MudTableSortLabel></MudTh>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.Sleep)">Sleep</MudTableSortLabel></MudTh>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.SleepType)">Sleep Type</MudTableSortLabel></MudTh>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)">Download</MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.Id)">Id</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.ImplantType)">Implant Type</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.Name)">Name</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.ManagerName)">Manager Name</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.CompileDateTime)">Compile DateTime</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.KillDateTime)">KillDateTime</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.ConnectionAttempts)">ConnectionAttempts</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.IncludedCommands)">Included Commands</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.IncludedModules)">Included Modules</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.Sleep)">Sleep</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<CompiledImplant, object>(x=>x.SleepType)">Sleep Type</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Download</MudTh>
         </HeaderContent>
         <RowTemplate Context="Rowcontext">
             <MudTd>@Rowcontext.Id</MudTd>

--- a/HardHatC2Client/Components/DirectoryListingTable.razor
+++ b/HardHatC2Client/Components/DirectoryListingTable.razor
@@ -25,14 +25,14 @@
         
     </ToolBarContent>
     <HeaderContent>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(0))">Name</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(1))">Length</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(2))">Owner</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(3))">Item Count</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(4))">CreationTimeUtc</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(5))">LastAccessTimeUtc</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(6))">LastWriteTimeUtc</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(7))">ACLs</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(0))">Name</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(1))">Length</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(2))">Owner</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(3))">Item Count</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(4))">CreationTimeUtc</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(5))">LastAccessTimeUtc</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(6))">LastWriteTimeUtc</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(7))">ACLs</MudTableSortLabel></MudTh>
     </HeaderContent>
     <RowTemplate>
         <MudTd><MudIcon Size="Size.Small" Class="m-2" Color=@GetColor(context.Name) Icon=@getIcon(context.Name)></MudIcon> @context.Name</MudTd>
@@ -52,10 +52,10 @@
                     {
                         <MudTable T="ACL" @ref=@_child_table Items="context.ACLs" HorizontalScrollbar="false" Virtualize="true" FixedHeader="true" Hover="true" Dense="true" Outlined="true" Striped="true" SortLabel="Sort By">
                             <HeaderContent>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<string[], string>(x => x.ElementAt(0))">Name</MudTableSortLabel></MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<string[], string>(x => x.ElementAt(1))">Type</MudTableSortLabel></MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<string[], string>(x => x.ElementAt(2))">Rights</MudTableSortLabel></MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<string[], string>(x => x.ElementAt(3))">Is Inherited</MudTableSortLabel></MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<string[], string>(x => x.ElementAt(0))">Name</MudTableSortLabel></MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<string[], string>(x => x.ElementAt(1))">Type</MudTableSortLabel></MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<string[], string>(x => x.ElementAt(2))">Rights</MudTableSortLabel></MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<string[], string>(x => x.ElementAt(3))">Is Inherited</MudTableSortLabel></MudTh>
                             </HeaderContent>
                             <RowTemplate Context="childcontext">
                                 <MudTd>@childcontext.IdentityRef</MudTd>

--- a/HardHatC2Client/Components/EditFileComponent.razor
+++ b/HardHatC2Client/Components/EditFileComponent.razor
@@ -60,7 +60,7 @@
                 Value = Src,
                 ReadOnly = !canEdit
             };
-        if (Settings.IsCheckedBox)
+        if (MainLayout.IsDarkMode)
         {
             editorInstance.Theme = "vs-dark";
         }

--- a/HardHatC2Client/Components/FileIOCTable.razor
+++ b/HardHatC2Client/Components/FileIOCTable.razor
@@ -10,11 +10,11 @@
         <MudTextField @bind-Value="searchString1" Placeholder="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
     </ToolBarContent>
     <HeaderContent>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<IOCFile, object>(x=>x.Name)">Name</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<IOCFile, object>(x=>x.UploadedHost)">Uploaded Host</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<IOCFile, object>(x=>x.UploadedPath)">Uploaded Path</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<IOCFile, object>(x=>x.Uploadtime)">Upload time</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<IOCFile, object>(x=>x.md5Hash)">md5 Hash</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<IOCFile, object>(x=>x.Name)">Name</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<IOCFile, object>(x=>x.UploadedHost)">Uploaded Host</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<IOCFile, object>(x=>x.UploadedPath)">Uploaded Path</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<IOCFile, object>(x=>x.Uploadtime)">Upload time</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<IOCFile, object>(x=>x.md5Hash)">md5 Hash</MudTableSortLabel></MudTh>
     </HeaderContent>
     <RowTemplate>
         <MudTd>@context.Name</MudTd>

--- a/HardHatC2Client/Components/GetPrivsTable.razor
+++ b/HardHatC2Client/Components/GetPrivsTable.razor
@@ -8,8 +8,8 @@
 
     </ToolBarContent>
     <HeaderContent>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<string[], string>(x=>x.ElementAt(0))">Privilege Name</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<string[], string>(x=>x.ElementAt(1))">Enabled Value</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<string[], string>(x=>x.ElementAt(0))">Privilege Name</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<string[], string>(x=>x.ElementAt(1))">Enabled Value</MudTableSortLabel></MudTh>
     </HeaderContent>
     <RowTemplate>
         <MudTd>@context[0]</MudTd>

--- a/HardHatC2Client/Components/HelpTable.razor
+++ b/HardHatC2Client/Components/HelpTable.razor
@@ -11,12 +11,12 @@
 
     </ToolBarContent>
     <HeaderContent>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(0))">Name</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(1))">Description</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(2))">Usage</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(3))">NeedsAdmin</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(4))">Opsec</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(6))">Keys</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(0))">Name</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(1))">Description</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(2))">Usage</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(3))">NeedsAdmin</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(4))">Opsec</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<FileSystemItem>, FileSystemItem>(x=>x.ElementAt(6))">Keys</MudTableSortLabel></MudTh>
     </HeaderContent>
     <RowTemplate>
         <MudTd>@context.Name</MudTd>

--- a/HardHatC2Client/Components/PrintEnvTable.razor
+++ b/HardHatC2Client/Components/PrintEnvTable.razor
@@ -8,8 +8,8 @@
 
     </ToolBarContent>
     <HeaderContent>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<string[], string>(x=>x.ElementAt(0))">Enviornment Var</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<string[], string>(x=>x.ElementAt(1))">Value</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<string[], string>(x=>x.ElementAt(0))">Enviornment Var</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<string[], string>(x=>x.ElementAt(1))">Value</MudTableSortLabel></MudTh>
     </HeaderContent>
     <RowTemplate>
         <MudTd>@context[0]</MudTd>

--- a/HardHatC2Client/Components/ProcessListingTable.razor
+++ b/HardHatC2Client/Components/ProcessListingTable.razor
@@ -9,13 +9,13 @@
         
     </ToolBarContent>
     <HeaderContent>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<ProcessItem>, ProcessItem>(x=>x.ElementAt(0))">Process Name</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<ProcessItem>, ProcessItem>(x=>x.ElementAt(1))">Process Path</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<ProcessItem>, ProcessItem>(x=>x.ElementAt(2))">Owner</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<ProcessItem>, ProcessItem>(x=>x.ElementAt(3))">PID</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<ProcessItem>, ProcessItem>(x=>x.ElementAt(4))">PPID</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<ProcessItem>, ProcessItem>(x=>x.ElementAt(5))">SessionID</MudTableSortLabel></MudTh>
-        <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<List<ProcessItem>, ProcessItem>(x=>x.ElementAt(6))">Arch</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<ProcessItem>, ProcessItem>(x=>x.ElementAt(0))">Process Name</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<ProcessItem>, ProcessItem>(x=>x.ElementAt(1))">Process Path</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<ProcessItem>, ProcessItem>(x=>x.ElementAt(2))">Owner</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<ProcessItem>, ProcessItem>(x=>x.ElementAt(3))">PID</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<ProcessItem>, ProcessItem>(x=>x.ElementAt(4))">PPID</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<ProcessItem>, ProcessItem>(x=>x.ElementAt(5))">SessionID</MudTableSortLabel></MudTh>
+        <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<List<ProcessItem>, ProcessItem>(x=>x.ElementAt(6))">Arch</MudTableSortLabel></MudTh>
     </HeaderContent>
     <RowTemplate>
         <MudTd>@context.ProcessName</MudTd>

--- a/HardHatC2Client/Components/TokenStoreTable.razor
+++ b/HardHatC2Client/Components/TokenStoreTable.razor
@@ -10,11 +10,11 @@
             <MudSpacer />
         </ToolBarContent>
         <HeaderContent>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<TokenStoreItem, object>(x=>x.Index)">#</MudTableSortLabel></MudTh>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<TokenStoreItem, object>(x=>x.Username)">Username</MudTableSortLabel></MudTh>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<TokenStoreItem, object>(x=>x.SID)">SID</MudTableSortLabel></MudTh>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<TokenStoreItem, object>(x=>x.PID)">PID</MudTableSortLabel></MudTh>
-            <MudTh Style="@setStyle(Settings.IsCheckedBox)"><MudTableSortLabel SortBy="new Func<TokenStoreItem, object>(x=>x.IsCurrent)">Current</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<TokenStoreItem, object>(x=>x.Index)">#</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<TokenStoreItem, object>(x=>x.Username)">Username</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<TokenStoreItem, object>(x=>x.SID)">SID</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<TokenStoreItem, object>(x=>x.PID)">PID</MudTableSortLabel></MudTh>
+            <MudTh Style="@setStyle(MainLayout.IsDarkMode)"><MudTableSortLabel SortBy="new Func<TokenStoreItem, object>(x=>x.IsCurrent)">Current</MudTableSortLabel></MudTh>
         </HeaderContent>
         <RowTemplate Context="Rowcontext">
             <MudTd>@Rowcontext.Index</MudTd>

--- a/HardHatC2Client/Pages/Credentials.razor
+++ b/HardHatC2Client/Pages/Credentials.razor
@@ -18,12 +18,12 @@
                                   OnCommitEditClick="@(() => Snackbar.Add("Commit Edit Handler Invoked"))" RowEditPreview="BackupItem" RowEditCancel="ResetItemToOriginalValues"
                                   RowEditCommit="ItemHasBeenCommitted" IsEditRowSwitchingBlocked="true">
                             <HeaderContent>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Name</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Domain</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Credential</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Type</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">SubType</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Capture Time</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Name</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Domain</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Credential</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Type</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">SubType</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Capture Time</MudTh>
                             </HeaderContent>
                             <RowTemplate Context="Rowcontext">
                                 <MudTd DataLabel="Name">@Rowcontext.Name</MudTd>
@@ -86,12 +86,12 @@
                                    CommitEditTooltip="Commit Edit"
                                   IsEditRowSwitchingBlocked="true">
                             <HeaderContent>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Name</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Domain</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Credential</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Type</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">SubType</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Capture Time</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Name</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Domain</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Credential</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Type</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">SubType</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Capture Time</MudTh>
                             </HeaderContent>
                             <RowTemplate Context="Rowcontext">
                                 <MudTd DataLabel="Name">@Rowcontext.Name</MudTd>

--- a/HardHatC2Client/Pages/Downloads.razor
+++ b/HardHatC2Client/Pages/Downloads.razor
@@ -29,13 +29,13 @@
             </style>
                         <MudTable Virtualize="true" Items="@DownloadedFiles" HorizontalScrollbar="true" FixedHeader="true" Height="400px" Hover="true" Dense="true" Outlined="true" Striped="true" RowClassFunc="@SelectedRowClassFunc" OnRowClick="RowClickEvent" @ref="mudTable" T="DownloadFile">
                             <HeaderContent>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Name </MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Host</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Original Path </MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Saved Location</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Download Time</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Download</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">View</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Name </MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Host</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Original Path </MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Saved Location</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Download Time</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Download</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">View</MudTh>
                             </HeaderContent>
                             <RowTemplate Context="Rowcontext">
                                 <MudTd>@Rowcontext.Name</MudTd>
@@ -88,11 +88,11 @@
                 </style>
                         <MudTable Virtualize="true" Items="@DownloadedFiles" HorizontalScrollbar="true" FixedHeader="true" Height="400px" Hover="true" Dense="true" Outlined="true" Striped="true" RowClassFunc="@SelectedRowClassFunc" OnRowClick="RowClickEvent" @ref="mudTable" T="DownloadFile">
                             <HeaderContent>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Name </MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Host</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Original Path </MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Saved Location</MudTh>
-                                <MudTh Style="@setStyle(Settings.IsCheckedBox)">Download Time</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Name </MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Host</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Original Path </MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Saved Location</MudTh>
+                                <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Download Time</MudTh>
                             </HeaderContent>
                             <RowTemplate Context="Rowcontext">
                                 <MudTd>@Rowcontext.Name</MudTd>

--- a/HardHatC2Client/Pages/HostedFiles.razor
+++ b/HardHatC2Client/Pages/HostedFiles.razor
@@ -11,9 +11,9 @@
 
 			<MudTable Items="@_hostedFiles" HorizontalScrollbar="true" FixedHeader="true" Height="400px" Hover="true" Dense="true" Outlined="true" Striped="true">
 				<HeaderContent>
-					<MudTh Style="@setStyle(Settings.IsCheckedBox)">Name</MudTh>
-					<MudTh Style="@setStyle(Settings.IsCheckedBox)">Upload Time</MudTh>
-					<MudTh Style="@setStyle(Settings.IsCheckedBox)">File Size</MudTh>
+					<MudTh Style="@setStyle(MainLayout.IsDarkMode)">Name</MudTh>
+					<MudTh Style="@setStyle(MainLayout.IsDarkMode)">Upload Time</MudTh>
+					<MudTh Style="@setStyle(MainLayout.IsDarkMode)">File Size</MudTh>
 				</HeaderContent>
 				<RowTemplate Context="Rowcontext">
 					<MudTd>@Rowcontext.Name</MudTd>
@@ -42,9 +42,9 @@
     
 			<MudTable Items="@_hostedFiles" HorizontalScrollbar="true" FixedHeader="true" Height="400px" Hover="true" Dense="true" Outlined="true" Striped="true">
 				<HeaderContent>
-					<MudTh Style="@setStyle(Settings.IsCheckedBox)">Name</MudTh>
-					<MudTh Style="@setStyle(Settings.IsCheckedBox)">Upload Time</MudTh>
-					<MudTh Style="@setStyle(Settings.IsCheckedBox)">File Size</MudTh>
+					<MudTh Style="@setStyle(MainLayout.IsDarkMode)">Name</MudTh>
+					<MudTh Style="@setStyle(MainLayout.IsDarkMode)">Upload Time</MudTh>
+					<MudTh Style="@setStyle(MainLayout.IsDarkMode)">File Size</MudTh>
 				</HeaderContent>
 				<RowTemplate Context="Rowcontext">
 					<MudTd>@Rowcontext.Name</MudTd>

--- a/HardHatC2Client/Pages/Implants.razor
+++ b/HardHatC2Client/Pages/Implants.razor
@@ -85,25 +85,25 @@
                             <MudTextField @bind-Value="searchString1" Placeholder="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
                         </ToolBarContent>
                     <HeaderContent>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"Number")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x => x.Number)">#</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"")"></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"Status")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Status)">Status</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"ExternalAddress")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.ExternalAddress)">External Address</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"ManagerName")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.ManagerName)">Manager</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"ConnectionType")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.ConnectionType)">Connection Type</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"Address")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.Address)">Address</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"Hostname")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.Hostname)">hostname</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"Username")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.Username)">username</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"Note")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Note)">note</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"ProcessName")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.ProcessName)">process</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"ProcessId")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.ProcessId)">pid</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"Integrity")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.Integrity)">Integrity</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"Arch")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.Arch)">arch</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"Sleep")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.Sleep)">Sleep Time</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"LastSeen")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.LastSeen)">lastseen</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"FirstSeen")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.FirstSeen)">firstseen</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"ImplantType")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.ImplantType)">Implant Type</MudTableSortLabel></MudTh>
-                                    <MudTh Style="@setStyle(Settings.IsCheckedBox,"")">Options</MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"Number")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x => x.Number)">#</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"")"></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"Status")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Status)">Status</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"ExternalAddress")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.ExternalAddress)">External Address</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"ManagerName")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.ManagerName)">Manager</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"ConnectionType")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.ConnectionType)">Connection Type</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"Address")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.Address)">Address</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"Hostname")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.Hostname)">hostname</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"Username")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.Username)">username</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"Note")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Note)">note</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"ProcessName")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.ProcessName)">process</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"ProcessId")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.ProcessId)">pid</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"Integrity")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.Integrity)">Integrity</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"Arch")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.Arch)">arch</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"Sleep")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.Metadata.Sleep)">Sleep Time</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"LastSeen")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.LastSeen)">lastseen</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"FirstSeen")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.FirstSeen)">firstseen</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"ImplantType")"><MudTableSortLabel SortBy="new Func<ExtImplant_Base, object>(x=>x.ImplantType)">Implant Type</MudTableSortLabel></MudTh>
+                                    <MudTh Style="@setStyle(MainLayout.IsDarkMode,"")">Options</MudTh>
                     </HeaderContent>
                     <RowTemplate Context="Rowcontext">
                                     <MudTd Style="@GetCellStyle("Number",Rowcontext)">@Rowcontext.Number</MudTd>

--- a/HardHatC2Client/Pages/Managers.razor
+++ b/HardHatC2Client/Pages/Managers.razor
@@ -28,16 +28,16 @@
 
             <MudTable Items="@managersList" Virtualize="true" HorizontalScrollbar="true" FixedHeader="true" Height="30vh" Hover="true" Dense="true" Outlined="true" Striped="true">
                 <HeaderContent>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Name</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Type</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Connection Address</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Connection Port</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Bind Address</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Bind Port</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Created Time</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Active</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">C2 Profile</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Options</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Name</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Type</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Connection Address</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Connection Port</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Bind Address</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Bind Port</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Created Time</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Active</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">C2 Profile</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Options</MudTh>
                 </HeaderContent>
                 <RowTemplate Context="rowContext">
                     <MudTd>@rowContext.Name</MudTd>
@@ -251,13 +251,13 @@
                             
             <MudTable Items="@managersList" Virtualize="true" HorizontalScrollbar="true" FixedHeader="true" Height="30vh" Hover="true" Dense="true" Outlined="true" Striped="true">
                 <HeaderContent>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Name</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Type</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Connection Address</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Connection Port</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Created Time</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Active</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Options</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Name</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Type</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Connection Address</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Connection Port</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Created Time</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Active</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Options</MudTh>
                 </HeaderContent>
                 <RowTemplate Context="rowContext">
                     <MudTd>@rowContext.Name</MudTd>

--- a/HardHatC2Client/Pages/Objectives.razor
+++ b/HardHatC2Client/Pages/Objectives.razor
@@ -270,7 +270,7 @@
         //find the tag with the name of the chip
         Tag tag = Tag.Existing_Tags.Find(x => x.Name.Equals(chipName, StringComparison.CurrentCultureIgnoreCase));
 
-        if(Settings.IsCheckedBox)
+        if(MainLayout.IsDarkMode)
         {
             //dark mode 
              return $"background:{tag.Color}; color:white;";

--- a/HardHatC2Client/Pages/PivotProxy.razor
+++ b/HardHatC2Client/Pages/PivotProxy.razor
@@ -10,13 +10,13 @@
             <h3 class="text-center">PivotProxy</h3>
             <MudTable Items="@_pivotProxyItems" HorizontalScrollbar="true" Virtualize="true" FixedHeader="true" Height="400px" Hover="true" Dense="true" Elevation="10" Outlined="true" Striped="true" T="PivotProxyItem">
                 <HeaderContent>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">EngineerId</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Bind Port</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Fwd Host</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Fwd Port</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">pivot Type</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">pivot Direction</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Options</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">EngineerId</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Bind Port</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Fwd Host</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Fwd Port</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">pivot Type</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">pivot Direction</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Options</MudTh>
                 </HeaderContent>
                 <RowTemplate Context="Rowcontext">
                     <MudTd >@Rowcontext.EngineerId</MudTd>
@@ -42,13 +42,13 @@
             <h3 class="text-center">PivotProxy</h3>
             <MudTable Items="@_pivotProxyItems" HorizontalScrollbar="true" Virtualize="true" FixedHeader="true" Height="400px" Hover="true" Dense="true" Elevation="10" Outlined="true" Striped="true" T="PivotProxyItem">
                 <HeaderContent>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">EngineerId</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Bind Port</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Fwd Host</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Fwd Port</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">pivot Type</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">pivot Direction</MudTh>
-                    <MudTh Style="@setStyle(Settings.IsCheckedBox)">Options</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">EngineerId</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Bind Port</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Fwd Host</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Fwd Port</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">pivot Type</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">pivot Direction</MudTh>
+                    <MudTh Style="@setStyle(MainLayout.IsDarkMode)">Options</MudTh>
                 </HeaderContent>
                 <RowTemplate Context="Rowcontext">
                     <MudTd >@Rowcontext.EngineerId</MudTd>

--- a/HardHatC2Client/Pages/ReconCenter.razor
+++ b/HardHatC2Client/Pages/ReconCenter.razor
@@ -42,9 +42,9 @@
                                 }
                             </ToolBarContent>
                             <Columns>
-                                <Column HeaderStyle="@setStyle(Settings.IsCheckedBox)" T="ReconCenterEntity.ReconCenterEntityProperty" Field="Name" Title="Property Name" IsEditable="true"/>
-                                <Column HeaderStyle="@setStyle(Settings.IsCheckedBox)" T="ReconCenterEntity.ReconCenterEntityProperty" Field="Value" CellStyleFunc="@_styleFunc" IsEditable="true"/>
-                                <Column HeaderStyle="@setStyle(Settings.IsCheckedBox)" T="ReconCenterEntity.ReconCenterEntityProperty" Field="Note" CellStyleFunc="@_styleFunc" IsEditable="true"/>
+                                <Column HeaderStyle="@setStyle(MainLayout.IsDarkMode)" T="ReconCenterEntity.ReconCenterEntityProperty" Field="Name" Title="Property Name" IsEditable="true"/>
+                                <Column HeaderStyle="@setStyle(MainLayout.IsDarkMode)" T="ReconCenterEntity.ReconCenterEntityProperty" Field="Value" CellStyleFunc="@_styleFunc" IsEditable="true"/>
+                                <Column HeaderStyle="@setStyle(MainLayout.IsDarkMode)" T="ReconCenterEntity.ReconCenterEntityProperty" Field="Note" CellStyleFunc="@_styleFunc" IsEditable="true"/>
                             </Columns>
                         </MudDataGrid>
 
@@ -113,9 +113,9 @@
                     }
                 </ToolBarContent>
                 <Columns>
-                    <Column HeaderStyle="@setStyle(Settings.IsCheckedBox)"  T="ReconCenterEntity.ReconCenterEntityProperty"  Field="Name" Title="Property Name" IsEditable="true" />
-                    <Column HeaderStyle="@setStyle(Settings.IsCheckedBox)"  T="ReconCenterEntity.ReconCenterEntityProperty"  Field="Value" CellStyleFunc="@_styleFunc" IsEditable="true" />
-                    <Column HeaderStyle="@setStyle(Settings.IsCheckedBox)"  T="ReconCenterEntity.ReconCenterEntityProperty"  Field="Note" CellStyleFunc="@_styleFunc" IsEditable="true" />
+                    <Column HeaderStyle="@setStyle(MainLayout.IsDarkMode)"  T="ReconCenterEntity.ReconCenterEntityProperty"  Field="Name" Title="Property Name" IsEditable="true" />
+                    <Column HeaderStyle="@setStyle(MainLayout.IsDarkMode)"  T="ReconCenterEntity.ReconCenterEntityProperty"  Field="Value" CellStyleFunc="@_styleFunc" IsEditable="true" />
+                    <Column HeaderStyle="@setStyle(MainLayout.IsDarkMode)"  T="ReconCenterEntity.ReconCenterEntityProperty"  Field="Note" CellStyleFunc="@_styleFunc" IsEditable="true" />
                 </Columns>
             </MudDataGrid>
 

--- a/HardHatC2Client/Pages/Settings.razor
+++ b/HardHatC2Client/Pages/Settings.razor
@@ -2,150 +2,135 @@
 @using HardHatCore.HardHatC2Client.Services
 @using HardHatCore.HardHatC2Client.Components
 @inject IJSRuntime js
+
 <h3 class="text-center">Settings</h3>
 <hr>
 <CascadingAuthenticationState>
-	<AuthorizeView Roles="Operator,TeamLead,Administrator,Guest">
-	<Authorized>
-		<h4>Theme</h4> 
-		<MudSwitch @bind-Checked="@IsCheckedBox" ThumbIcon="@Icons.Material.Filled.LightMode" Color="Color.Success" Class="ma-4" T="bool" Label="Toggle Light/Dark Mode"/>
-		<MudSelect @bind-Value="_InteractInputMode" T="InteractCommandEntryWindow.InteractInputMode" Label="Interact Input Mode" AnchorOrigin="Origin.BottomCenter">
-			@foreach (InteractCommandEntryWindow.InteractInputMode value in Enum.GetValues(typeof(InteractCommandEntryWindow.InteractInputMode)))
+    <AuthorizeView Roles="Operator,TeamLead,Administrator,Guest">
+        <Authorized>
+            <MudSelect @bind-Value="_InteractInputMode" T="InteractCommandEntryWindow.InteractInputMode" Label="Interact Input Mode" AnchorOrigin="Origin.BottomCenter">
+                @foreach (InteractCommandEntryWindow.InteractInputMode value in Enum.GetValues(typeof(InteractCommandEntryWindow.InteractInputMode)))
+                {
+                    <MudSelectItem Value="@value" />
+                }
+            </MudSelect>
+            <MudSwitch @bind-Checked="@InteractCommandEntryWindow.AutocompleteSearchShowAllItems" Color="Color.Success" Class="ma-4" T="bool" Label="Interact Autocomplete ShowAll" />
+
+            <MudButton style="background:var(--font-color);color:var(--background)" OnClick=@RefreshClientPlugins Disabled=@context.User.IsInRole("Guest")><MudText>Refresh Client Plugins</MudText></MudButton>
+            <br>
+            <br>
+            <MudButton style="background:var(--font-color);color:var(--background)" OnClick=@RefreshTeamServerPlugins Disabled=@context.User.IsInRole("Guest")><MudText>Refresh Server Plugins</MudText></MudButton>
+            <br>
+            <br>
+
+            @if (context.User.IsInRole("Administrator") || context.User.IsInRole("TeamLead"))
             {
-                <MudSelectItem Value="@value" />
+                <h3 class="text-center">Admin Dashboard</h3>
+                <hr>
+                <MudContainer MaxWidth="MaxWidth.Medium">
+                    <MudTabs>
+                        <MudPaper Height="500px" Width="100%" Square="true" Class="pa-4">
+                            @if (context.User.IsInRole("Administrator"))
+                            {
+                                <MudTabPanel Text="User Management">
+                                    <MudTabs Elevation="5" Rounded="true" PanelClass="pa-6" Centered="true" Color="@Color.Primary">
+                                        <MudTabPanel Text="Create User">
+                                            <h4>Create User Form</h4>
+                                            <MudForm @ref="form" @bind-IsValid="@success" @bind-Errors="@errors">
+                                                <MudTextField T="string" @bind-Value="UserName" Label="Username" Required="true" RequiredError="User name is required!" />
+                                                <MudTextField T="string" @bind-Value="Password" Label="Password" HelperText="Choose a strong password" @ref="pwField1" InputType="InputType.Password" Required="true" RequiredError="Password is required!" />
+                                                <MudTextField T="string" Label="Confirm Password" HelperText="Repeat the password" InputType="InputType.Password" Validation="@(new Func<string, string>(PasswordMatch))" />
+                                                <MudSelect Class="mb-4 mt-4" T="string" Label="Role" Required="true" @bind-value="Role" RequiredError="Role is required!">
+                                                    <MudSelectItem Value=@("Operator")>Operator</MudSelectItem>
+                                                    <MudSelectItem Value=@("TeamLead")>TeamLead</MudSelectItem>
+                                                    <MudSelectItem Value=@("Guest")>Guest</MudSelectItem>
+                                                </MudSelect>
+                                                <div class="d-flex align-center justify-space-between">
+                                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!success)" Class="ml-auto" @onclick="@handleValidCreateUser">Create</MudButton>
+                                                </div>
+                                            </MudForm>
+                                        </MudTabPanel>
+                                    </MudTabs>
+                                </MudTabPanel>
+                            }
+                            @if (context.User.IsInRole("Administrator") || context.User.IsInRole("TeamLead"))
+                            {
+                                <MudTabPanel Text="Webhooks">
+                                    <Webhooks></Webhooks>
+                                </MudTabPanel>
+                            }
+                        </MudPaper>
+                    </MudTabs>
+                </MudContainer>
             }
-		</MudSelect>
-		<MudSwitch @bind-Checked="@InteractCommandEntryWindow.AutocompleteSearchShowAllItems" Color="Color.Success" Class="ma-4" T="bool" Label="Interact Autocomplete ShowAll" />
-
-		@if (IsCheckedBox == false)
-		{
-			selectedTheme = "Light";
-		}
-		else
-		{
-			selectedTheme = "Dark";
-		}
-			<MudButton style="background:var(--font-color);color:var(--background)" OnClick=@RefreshClientPlugins Disabled=@context.User.IsInRole("Guest") ><MudText>Refresh Client Plugins</MudText></MudButton>
-		<br>
-		<br>
-			<MudButton style="background:var(--font-color);color:var(--background)" OnClick=@RefreshTeamServerPlugins Disabled=@context.User.IsInRole("Guest")><MudText>Refresh Server Plugins</MudText></MudButton>
-		<br>
-		<br>
-
-		@if (context.User.IsInRole("Administrator") || context.User.IsInRole("TeamLead"))
-		{
-			<h3 class="text-center">Admin Dashboard</h3>
-			<hr>
-			<MudContainer MaxWidth="MaxWidth.Medium">
-				<MudTabs>
-					<MudPaper Height="500px" Width="100%" Square="true" Class="pa-4">
-						@if (context.User.IsInRole("Administrator"))
-						{
-							<MudTabPanel Text="User Management">
-								<MudTabs Elevation="5" Rounded="true" PanelClass="pa-6" Centered="true" Color="@Color.Primary">
-									<MudTabPanel Text="Create User">
-										<h4>Create User Form</h4>
-										<MudForm @ref="form" @bind-IsValid="@success" @bind-Errors="@errors">
-											<MudTextField T="string" @bind-Value="UserName" Label="Username" Required="true" RequiredError="User name is required!" />
-											<MudTextField T="string" @bind-Value="Password" Label="Password" HelperText="Choose a strong password" @ref="pwField1" InputType="InputType.Password" Required="true" RequiredError="Password is required!" />
-											<MudTextField T="string" Label="Confirm Password" HelperText="Repeat the password" InputType="InputType.Password" Validation="@(new Func<string, string>(PasswordMatch))" />
-											<MudSelect Class="mb-4 mt-4" T="string" Label="Role" Required="true" @bind-value="Role" RequiredError="Role is required!">
-												<MudSelectItem Value=@("Operator")>Operator</MudSelectItem>
-												<MudSelectItem Value=@("TeamLead")>TeamLead</MudSelectItem>
-												<MudSelectItem Value=@("Guest")>Guest</MudSelectItem>
-											</MudSelect>
-											<div class="d-flex align-center justify-space-between">
-												<MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!success)" Class="ml-auto" @onclick="@handleValidCreateUser">Create</MudButton>
-											</div>
-										</MudForm>
-									</MudTabPanel>
-								</MudTabs>
-							</MudTabPanel>
-						}
-						@if (context.User.IsInRole("Administrator") || context.User.IsInRole("TeamLead"))
-						{
-							<MudTabPanel Text="Webhooks">
-								<Webhooks></Webhooks>
-							</MudTabPanel>
-						}
-					</MudPaper>
-				</MudTabs>
-			</MudContainer>
-		}
-	</Authorized>
-	<NotAuthorized>
-        <h1 class="text-center">Not Authorized</h1>
+        </Authorized>
+        <NotAuthorized>
+            <h1 class="text-center">Not Authorized</h1>
             <UnAuthorizedDialogBox></UnAuthorizedDialogBox>
-    </NotAuthorized>
-	</AuthorizeView>
+        </NotAuthorized>
+    </AuthorizeView>
 </CascadingAuthenticationState>
 
+@code {
 
-@code{
+    #region Settings
 
-	#region Settings
+    public static InteractCommandEntryWindow.InteractInputMode _InteractInputMode { get; set; } = InteractCommandEntryWindow.InteractInputMode.Classic;
 
-	public static string selectedTheme = "Dark";
-	private static List<string> themes = new List<string> { "Light", "Dark" };
-	public static bool IsCheckedBox = true;
-	public static InteractCommandEntryWindow.InteractInputMode _InteractInputMode { get; set; } = InteractCommandEntryWindow.InteractInputMode.Classic;
-
-	#endregion
+    #endregion
 
 
-	#region Admin Dashboard
+    #region Admin Dashboard
 
-	private MudForm form;
-	private string UserName { get; set; }
-	private string Password { get; set; }
-	private string Role { get; set; }
-	private bool success;
-	private string[] errors;
-	private MudTextField<string> pwField1;
-	private MudTextField<string> pwField2;
+    private MudForm form;
+    private string UserName { get; set; }
+    private string Password { get; set; }
+    private string Role { get; set; }
+    private bool success;
+    private string[] errors;
+    private MudTextField<string> pwField1;
+    private MudTextField<string> pwField2;
 
-	private async Task handleValidCreateUser()
-	{
-		try
-		{
-			bool CreateResult = await HardHatHubClient._hub.CreateUser(UserName, Password,Role);
-			if(CreateResult)
-			{
-				Login.ShowSuccessToast($"User {UserName} Created! Please provide operator with credentials!");
-			}
-			else
-			{
-				Login.ShowErrorToast("User Creation Failed, user may already exist try logging in!");
-			}
+    private async Task handleValidCreateUser()
+    {
+        try
+        {
+            bool CreateResult = await HardHatHubClient._hub.CreateUser(UserName, Password, Role);
+            if (CreateResult)
+            {
+                Login.ShowSuccessToast($"User {UserName} Created! Please provide operator with credentials!");
+            }
+            else
+            {
+                Login.ShowErrorToast("User Creation Failed, user may already exist try logging in!");
+            }
 
-		}
-		catch (Exception e)
-		{
-			Console.WriteLine(e.Message);
-			Login.ShowErrorToast($"User Creation Failed, {e.Message}");
-		}
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+            Login.ShowErrorToast($"User Creation Failed, {e.Message}");
+        }
+    }
 
-	}
+    private static async Task RefreshClientPlugins()
+    {
+        Plugin_Management.PluginService.RefreshPlugins();
+        Login.ShowSuccessToast("Client Plugins Refreshed!");
+    }
 
-	private static async Task RefreshClientPlugins()
-	{
-		Plugin_Management.PluginService.RefreshPlugins();
-		Login.ShowSuccessToast("Client Plugins Refreshed!");
-	}
+    private static async Task RefreshTeamServerPlugins()
+    {
+        await HardHatHubClient._hub.RefreshTeamserverPlugins();
+        Login.ShowSuccessToast("Teamserver Plugins Refreshed!");
+    }
 
-	private static async Task RefreshTeamServerPlugins()
-	{
-		await HardHatHubClient._hub.RefreshTeamserverPlugins();
-		Login.ShowSuccessToast("Teamserver Plugins Refreshed!");
-	}
+    private string PasswordMatch(string value)
+    {
+        if (value != pwField1.Value)
+            return "Passwords do not match!";
+        return null;
+    }
 
-	private string PasswordMatch(string value)
-	{
-		if (value != pwField1.Value)
-			return "Passwords do not match!";
-		return null;
-	}
-
-#endregion
-	
+    #endregion
 }

--- a/HardHatC2Client/Pages/ToolBoxes.razor
+++ b/HardHatC2Client/Pages/ToolBoxes.razor
@@ -25,8 +25,8 @@
                                 <MudTextField Variant="Variant.Outlined" @bind-Value="searchString1" Placeholder="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
                             </ToolBarContent>
     <Columns>
-        <PropertyColumn HeaderStyle="@setStyle(Settings.IsCheckedBox)" Property="x => x.commandName" Title="Command Name" CellStyleFunc="@_styleFunc" IsEditable="false"/>
-                    <TemplateColumn CellClass="d-flex" HeaderStyle="@setStyle(Settings.IsCheckedBox)" Title="Opsec Status" CellStyleFunc="@_styleFunc" IsEditable="true">
+        <PropertyColumn HeaderStyle="@setStyle(MainLayout.IsDarkMode)" Property="x => x.commandName" Title="Command Name" CellStyleFunc="@_styleFunc" IsEditable="false"/>
+                    <TemplateColumn CellClass="d-flex" HeaderStyle="@setStyle(MainLayout.IsDarkMode)" Title="Opsec Status" CellStyleFunc="@_styleFunc" IsEditable="true">
             <CellTemplate Context="cellcontext">
                             <MudSelect Variant="Variant.Outlined" ValueChanged="(e)=>OpsecChanged(selectedItem1.commandName,e)" T="CommandItem.OpsecStatus">
                                 @foreach (CommandItem.OpsecStatus opsec in Enum.GetValues(typeof(CommandItem.OpsecStatus)))
@@ -36,8 +36,8 @@
             </MudSelect>
             </CellTemplate>
         </TemplateColumn>
-        <PropertyColumn HeaderStyle="@setStyle(Settings.IsCheckedBox)" Property="x=>x.MitreTechnique" Title="Mitre ATT&CK Map" CellStyleFunc="@_styleFunc" IsEditable="true"/>
-        <TemplateColumn HeaderStyle="@setStyle(Settings.IsCheckedBox)" CellStyleFunc="@_styleFunc" CellClass="d-flex">
+        <PropertyColumn HeaderStyle="@setStyle(MainLayout.IsDarkMode)" Property="x=>x.MitreTechnique" Title="Mitre ATT&CK Map" CellStyleFunc="@_styleFunc" IsEditable="true"/>
+        <TemplateColumn HeaderStyle="@setStyle(MainLayout.IsDarkMode)" CellStyleFunc="@_styleFunc" CellClass="d-flex">
             <CellTemplate Context="editCellContext">
                 <MudIconButton Icon="@Icons.Material.Outlined.Edit" OnClick="@editCellContext.Actions.StartEditingItemAsync" />
             </CellTemplate>
@@ -81,8 +81,8 @@
                                 <MudTextField @bind-Value="searchString1" Placeholder="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
                             </ToolBarContent>
     <Columns>
-        <PropertyColumn HeaderStyle="@setStyle(Settings.IsCheckedBox)" Property="x => x.commandName" Title="Command Name" CellStyleFunc="@_styleFunc" IsEditable="false"/>
-                    <TemplateColumn CellClass="d-flex" HeaderStyle="@setStyle(Settings.IsCheckedBox)" Title="Opsec Status" CellStyleFunc="@_styleFunc" IsEditable="false">
+        <PropertyColumn HeaderStyle="@setStyle(MainLayout.IsDarkMode)" Property="x => x.commandName" Title="Command Name" CellStyleFunc="@_styleFunc" IsEditable="false"/>
+                    <TemplateColumn CellClass="d-flex" HeaderStyle="@setStyle(MainLayout.IsDarkMode)" Title="Opsec Status" CellStyleFunc="@_styleFunc" IsEditable="false">
             <CellTemplate Context="cellcontext">
                             <MudSelect ValueChanged="(e)=>OpsecChanged(selectedItem1.commandName,e)" T="CommandItem.OpsecStatus">
                                 @foreach (CommandItem.OpsecStatus opsec in Enum.GetValues(typeof(CommandItem.OpsecStatus)))
@@ -92,8 +92,8 @@
             </MudSelect>
             </CellTemplate>
         </TemplateColumn>
-        <PropertyColumn HeaderStyle="@setStyle(Settings.IsCheckedBox)" Property="x=>x.MitreTechnique" Title="Mitre ATT&CK Map" CellStyleFunc="@_styleFunc" IsEditable="false"/>
-        <TemplateColumn HeaderStyle="@setStyle(Settings.IsCheckedBox)" CellStyleFunc="@_styleFunc" CellClass="d-flex">
+        <PropertyColumn HeaderStyle="@setStyle(MainLayout.IsDarkMode)" Property="x=>x.MitreTechnique" Title="Mitre ATT&CK Map" CellStyleFunc="@_styleFunc" IsEditable="false"/>
+        <TemplateColumn HeaderStyle="@setStyle(MainLayout.IsDarkMode)" CellStyleFunc="@_styleFunc" CellClass="d-flex">
             <CellTemplate Context="editCellContext">
                 <MudIconButton Icon="@Icons.Material.Outlined.Edit" OnClick="@editCellContext.Actions.StartEditingItemAsync" />
             </CellTemplate>

--- a/HardHatC2Client/Shared/MainLayout.razor
+++ b/HardHatC2Client/Shared/MainLayout.razor
@@ -6,28 +6,27 @@
 @using MudBlazor.Extensions.Helper;
 @inherits LayoutComponentBase
 @inject IJSRuntime js
+@inject Blazored.LocalStorage.ILocalStorageService LocalStorageService
 
 
-<BlazoredToasts 
-    Position="ToastPosition.BottomRight"
-    IconType="IconType.FontAwesome"
-				
-	SuccessIcon="fas fa-thumbs-up"
-	ErrorIcon="fas fa-bug"
-	InfoIcon="fas fa-info-circle"
-	WarningIcon="fas fa-exclamation-triangle"
-    SuccessClass="success-toast-override"
-    Timeout="6"
-	ShowCloseButton="true"
-    ShowProgressBar="true"/>
+<BlazoredToasts Position="ToastPosition.BottomRight"
+                IconType="IconType.FontAwesome"
+                SuccessIcon="fas fa-thumbs-up"
+                ErrorIcon="fas fa-bug"
+                InfoIcon="fas fa-info-circle"
+                WarningIcon="fas fa-exclamation-triangle"
+                SuccessClass="success-toast-override"
+                Timeout="6"
+                ShowCloseButton="true"
+                ShowProgressBar="true" />
 
-<MudThemeProvider Theme="MyCustomTheme" @bind-IsDarkMode="@Settings.IsCheckedBox"/>
-<MudDialogProvider/>
-<MudSnackbarProvider/>
-   
-@if(Login.isVisible)
+<MudThemeProvider Theme="@customTheme" @bind-IsDarkMode="@IsDarkMode" />
+<MudDialogProvider />
+<MudSnackbarProvider />
+
+@if (Login.isVisible)
 {
-    @if(Login.IsLoggedIn)
+    @if (Login.IsLoggedIn)
     {
         Login.isVisible = false;
     }
@@ -36,85 +35,94 @@
     </MudOverlay>
 }
 
-@if(Login.IsLoggedIn)
+@if (Login.IsLoggedIn)
 {
-<MudLayout>
-    <MudAppBar Color="MudBlazor.Color.Dark" Dense="true" Elevation="5">
-        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
-        <MudSpacer/>
-        @if (TeamServerStatus.Equals("online", StringComparison.CurrentCultureIgnoreCase))
-        {
+    <MudLayout>
+        <MudAppBar Color="Color.Dark" Dense="true" Elevation="5">
+            <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@ToggleDrawer" />
+            <MudImage Src="Images/hardhat c2-orange - just helmet large.svg" Width="50"></MudImage>
+            <MudText Color="Color.Primary" Typo="Typo.h6">HardHat C2</MudText>
+            <MudSpacer />
+            @if (TeamServerStatus.Equals("online", StringComparison.CurrentCultureIgnoreCase))
+            {
                 <MudIcon Class="mx-2" Title="Teamserver Status" Icon="@Icons.Material.Outlined.CheckCircle" Color="Color.Success"></MudIcon>
-        }
-        else if(TeamServerStatus.Equals("offline", StringComparison.CurrentCultureIgnoreCase))
-        {
+            }
+            else if (TeamServerStatus.Equals("offline", StringComparison.CurrentCultureIgnoreCase))
+            {
                 <MudIcon Class="mx-2" Title="Teamserver Status" Icon="@Icons.Material.Filled.ErrorOutline" Color="Color.Error"></MudIcon>
+            }
+            else
+            {
+                <MudIcon Class="mx-2" Title="Teamserver Status" Icon="@Icons.Material.Filled.ErrorOutline" Color="Color.Warning"></MudIcon>
+            }
+
+            <MudIconButton Title="Github" Class="mx-2" Href="https://github.com/DragoQCC/HardHatC2"
+                           Target="_blank"
+                           Variant="Variant.Filled"
+                           Icon="@Icons.Custom.Brands.GitHub"
+                           Color="Color.Primary">
+            </MudIconButton>
+
+            <MudIconButton Title="Discord Community" Class="mx-2" Href="https://discord.gg/npW2yy7JFK"
+                           Target="_blank"
+                           Variant="Variant.Filled"
+                           Icon="@Icons.Custom.Brands.Discord"
+                           Color="Color.Primary">
+            </MudIconButton>
+
+            <MudIconButton Icon="@Icons.Material.Filled.LightMode"
+                           Size="Size.Large"
+                           Color="IsDarkMode ? Color.Primary : Color.Default"
+                           OnClick="ChangeThemeAsync">
+            </MudIconButton>
+
+            <MudMenu Class="mx-2" ActivationEvent="@MouseEvent.MouseOver" AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.TopRight">
+                <ActivatorContent>
+                    <MudAvatar>
+                        <MudIcon Icon="@MaterialDesignIcons.Normal.AccountHardHat" />
+                    </MudAvatar>
+                </ActivatorContent>
+                <ChildContent>
+                    <MudMenuItem Disabled="true">Welcome @Login.SignedInUser</MudMenuItem>
+                    <MudMenuItem OnClick="NavigateToSettings">Settings</MudMenuItem>
+                    <MudMenuItem OnClick="Login.HandleSignOut">Sign Out</MudMenuItem>
+                </ChildContent>
+            </MudMenu>
+        </MudAppBar>
+        @if (Login._hhUser != null && Login._hhUser.Roles.Contains("Administrator", StringComparer.OrdinalIgnoreCase))
+        {
+            <MudDrawer ClipMode="DrawerClipMode.Docked" @bind-Open="@isDrawerOpen" Elevation="10" Variant="@DrawerVariant.Mini" OpenMiniOnHover="false">
+                <MudNavMenu Color="Color.Warning" Margin="Margin.Dense" Bordered="true">
+                    <MudNavLink Class="py-2" href="Index" Icon="@Icons.Material.Outlined.Home" Match="NavLinkMatch.All">Home</MudNavLink>
+                    <MudNavLink Class="py-2" href="Objectives" Icon="@Icons.Material.Outlined.Checklist" Match="NavLinkMatch.All">Objectives</MudNavLink>
+                    <MudNavLink Class="py-2" href="Settings" Icon="@Icons.Material.Outlined.Settings" Match="NavLinkMatch.All">Settings</MudNavLink>
+                </MudNavMenu>
+            </MudDrawer>
         }
         else
         {
-                <MudIcon Class="mx-2" Title="Teamserver Status" Icon="@Icons.Material.Filled.ErrorOutline" Color="Color.Warning"></MudIcon>
+            <MudDrawer ClipMode="DrawerClipMode.Docked" @bind-Open="@isDrawerOpen" Elevation="10" Variant="@DrawerVariant.Mini" OpenMiniOnHover="false">
+                <MudNavMenu Color="Color.Warning" Margin="Margin.Dense" Bordered="true">
+                    <MudNavLink Class="py-2" href="Index" Icon="@Icons.Material.Outlined.Home" Match="NavLinkMatch.All">Home</MudNavLink>
+                    <MudNavLink Class="py-2" href="Managers" Icon="@Icons.Material.Outlined.Headphones" Match="NavLinkMatch.All">Managers</MudNavLink>
+                    <MudNavLink Class="py-2" href="Implants" Icon="@Icons.Material.Outlined.Construction" Match="NavLinkMatch.All">Implants</MudNavLink>
+                    <MudNavLink Class="py-2" href="ImplantInteract" Icon="@Icons.Material.Outlined.Engineering" Match="NavLinkMatch.All">ImplantInteract</MudNavLink>
+                    <MudNavLink Class="py-2" href="Notes" Icon="@Icons.Material.Outlined.Note" Match="NavLinkMatch.All">Notes</MudNavLink>
+                    <MudNavLink Class="py-2" href="ReconCenter" Icon="@Icons.Material.Outlined.Keyboard" Match="NavLinkMatch.All">Recon Center</MudNavLink>
+                    <MudNavLink Class="py-2" href="ToolBoxes" Icon="@Icons.Material.Outlined.BuildCircle" Match="NavLinkMatch.All">ToolBoxes</MudNavLink>
+                    <MudNavLink Class="py-2" href="PivotProxy" Icon="@Icons.Material.Outlined.CompareArrows" Match="NavLinkMatch.All">Pivot Proxy</MudNavLink>
+                    <MudNavLink Class="py-2" href="EventHistory" Icon="@Icons.Material.Outlined.History" Match="NavLinkMatch.All">Event History</MudNavLink>
+                    <MudNavLink Class="py-2" href="Credentials" Icon="@Icons.Material.Outlined.CreditCard" Match="NavLinkMatch.All">Credentials</MudNavLink>
+                    <MudNavLink Class="py-2" href="Downloads" Icon="@Icons.Material.Outlined.Download" Match="NavLinkMatch.All">Downloads</MudNavLink>
+                    <MudNavLink Class="py-2" href="HostedFiles" Icon="@Icons.Material.Outlined.Upload" Match="NavLinkMatch.All">Hosted Files</MudNavLink>
+                    <MudNavLink Class="py-2" href="Objectives" Icon="@Icons.Material.Outlined.Checklist" Match="NavLinkMatch.All">Objectives</MudNavLink>
+                    <MudNavLink Class="py-2" href="Settings" Icon="@Icons.Material.Outlined.Settings" Match="NavLinkMatch.All">Settings</MudNavLink>
+                </MudNavMenu>
+            </MudDrawer>
         }
-
-        <MudIconButton Title="Github" Class="mx-2" Href="https://github.com/DragoQCC/HardHatC2"
-                   Target="_blank"
-                   Variant="Variant.Filled"
-                   Icon="@Icons.Custom.Brands.GitHub"
-                   Color="Color.Primary">
-        </MudIconButton>
-        
-        <MudIconButton Title="Discord Community" Class="mx-2" Href="https://discord.gg/npW2yy7JFK"
-                   Target="_blank"
-                   Variant="Variant.Filled"
-                   Icon="@Icons.Custom.Brands.Discord"
-                   Color="Color.Primary">
-        </MudIconButton>
-            <MudMenu Class="mx-2" ActivationEvent="@MouseEvent.MouseOver" AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.TopRight">
-            <ActivatorContent>
-                <MudAvatar>
-                    <MudIcon Icon="@MaterialDesignIcons.Normal.AccountHardHat" />
-                </MudAvatar>
-            </ActivatorContent>
-            <ChildContent>
-                <MudMenuItem Disabled="true" >Welcome @Login.SignedInUser</MudMenuItem>
-                <MudMenuItem OnClick="NavigateToSettings">Settings</MudMenuItem>
-                <MudMenuItem OnClick="Login.HandleSignOut">Sign Out</MudMenuItem>
-            </ChildContent>
-        </MudMenu>
-    </MudAppBar>
-    @if(Login._hhUser != null && Login._hhUser.Roles.Contains("Administrator",StringComparer.OrdinalIgnoreCase))
-    {
-        <MudDrawer ClipMode="DrawerClipMode.Docked" @bind-Open="@open" Elevation="10" Variant="@DrawerVariant.Mini" OpenMiniOnHover="false">
-            <MudNavMenu Color="Color.Warning" Margin="Margin.Dense" Bordered="true">
-                <MudNavLink Class="py-2" href="Index" Icon="@Icons.Material.Outlined.Home" Match="NavLinkMatch.All">Home</MudNavLink>
-                <MudNavLink Class="py-2" href="Objectives" Icon="@Icons.Material.Outlined.Checklist" Match="NavLinkMatch.All">Objectives</MudNavLink>
-                <MudNavLink Class="py-2" href="Settings" Icon="@Icons.Material.Outlined.Settings" Match="NavLinkMatch.All">Settings</MudNavLink>
-            </MudNavMenu>
-        </MudDrawer>
-    }
-    else
-    {
-        <MudDrawer  ClipMode="DrawerClipMode.Docked" @bind-Open="@open" Elevation="10" Variant="@DrawerVariant.Mini" OpenMiniOnHover="false">
-            <MudNavMenu Color="Color.Warning" Margin="Margin.Dense" Bordered="true">
-                <MudNavLink Class="py-2" href="Index" Icon="@Icons.Material.Outlined.Home" Match="NavLinkMatch.All">Home</MudNavLink>
-                <MudNavLink Class="py-2" href="Managers" Icon="@Icons.Material.Outlined.Headphones" Match="NavLinkMatch.All">Managers</MudNavLink>
-                <MudNavLink Class="py-2" href="Implants" Icon="@Icons.Material.Outlined.Construction" Match="NavLinkMatch.All">Implants</MudNavLink>
-                <MudNavLink Class="py-2" href="ImplantInteract" Icon="@Icons.Material.Outlined.Engineering" Match="NavLinkMatch.All">ImplantInteract</MudNavLink>
-                <MudNavLink Class="py-2" href="Notes" Icon="@Icons.Material.Outlined.Note" Match="NavLinkMatch.All">Notes</MudNavLink>
-                <MudNavLink Class="py-2" href="ReconCenter" Icon="@Icons.Material.Outlined.Keyboard" Match="NavLinkMatch.All">Recon Center</MudNavLink>
-                <MudNavLink Class="py-2" href="ToolBoxes" Icon="@Icons.Material.Outlined.BuildCircle" Match="NavLinkMatch.All">ToolBoxes</MudNavLink>
-                <MudNavLink Class="py-2" href="PivotProxy" Icon="@Icons.Material.Outlined.CompareArrows" Match="NavLinkMatch.All">Pivot Proxy</MudNavLink>
-                <MudNavLink Class="py-2" href="EventHistory" Icon="@Icons.Material.Outlined.History" Match="NavLinkMatch.All">Event History</MudNavLink>
-                <MudNavLink Class="py-2" href="Credentials" Icon="@Icons.Material.Outlined.CreditCard" Match="NavLinkMatch.All">Credentials</MudNavLink>
-                <MudNavLink Class="py-2" href="Downloads" Icon="@Icons.Material.Outlined.Download" Match="NavLinkMatch.All">Downloads</MudNavLink>
-                <MudNavLink Class="py-2" href="HostedFiles" Icon="@Icons.Material.Outlined.Upload" Match="NavLinkMatch.All">Hosted Files</MudNavLink>
-                <MudNavLink Class="py-2" href="Objectives" Icon="@Icons.Material.Outlined.Checklist" Match="NavLinkMatch.All">Objectives</MudNavLink>
-                <MudNavLink Class="py-2"  href="Settings" Icon="@Icons.Material.Outlined.Settings" Match="NavLinkMatch.All">Settings</MudNavLink>
-            </MudNavMenu>
-        </MudDrawer>
-    }
-    <MudMainContent Class="px-4">
-        @Body
-    </MudMainContent>
+        <MudMainContent Class="px-4">
+            @Body
+        </MudMainContent>
     </MudLayout>
 }
 else
@@ -124,106 +132,102 @@ else
     </MudMainContent>
 }
 
-@code{
+@code {
     [Inject]
     public NavigationManager Nav { get; set; }
     public static string TeamServerStatus { get; set; } = "Unknown";
-    public static bool open { get; set; } = false;
-    MudTheme MyCustomTheme = new MudTheme()
-        {
-            Palette = new Palette()
-            {
-                Primary = "#FB8C00",
-                Warning = "#FB8C00",
-            },
-            PaletteDark = new Palette()
-            {
-                Black = "#27272f",
-                Background = "#32333d",
-                BackgroundGrey = "#27272f",
-                Surface = "#373740",
-                DrawerBackground = "#2d2d38", //Custom = #2d2d38 , original = #27272f
-                DrawerText = "rgba(255,255,255, 0.50)",
-                DrawerIcon = "rgba(255,255,255, 0.50)",
-                AppbarBackground = "#27272f",
-                AppbarText = "rgba(255,255,255, 0.70)",
-                TextPrimary = "rgba(255,255,255, 0.70)",
-                TextSecondary = "rgba(255,255,255, 0.50)",
-                ActionDefault = "#adadb1",
-                ActionDisabled = "rgba(255,255,255, 0.26)",
-                ActionDisabledBackground = "rgba(255,255,255, 0.12)",
-                Primary = "#FB8C00",
-                Warning = "#FB8C00",
-            }
-        };
+    private bool isDrawerOpen = true;
+    // We need to make the setter private to disallow outsiders from changing its value
+    public static bool IsDarkMode { get; private set; } = true;
 
-    private async Task NavigateToSettings()
+    private MudTheme customTheme = new MudTheme()
+    {
+        Palette = new PaletteLight()
+        {
+            Primary = "#FB8C00",
+            Warning = "#FB8C00",
+        },
+        PaletteDark = new PaletteDark()
+        {
+            Black = "#27272f",
+            Background = "#32333d",
+            BackgroundGrey = "#27272f",
+            Surface = "#373740",
+            DrawerBackground = "#2d2d38", //Custom = #2d2d38 , original = #27272f
+            DrawerText = "rgba(255,255,255, 0.50)",
+            DrawerIcon = "rgba(255,255,255, 0.50)",
+            AppbarBackground = "#27272f",
+            AppbarText = "rgba(255,255,255, 0.70)",
+            TextPrimary = "rgba(255,255,255, 0.70)",
+            TextSecondary = "rgba(255,255,255, 0.50)",
+            ActionDefault = "#adadb1",
+            ActionDisabled = "rgba(255,255,255, 0.26)",
+            ActionDisabledBackground = "rgba(255,255,255, 0.12)",
+            Primary = "#FB8C00",
+            Warning = "#FB8C00",
+        }
+    };
+
+    private void NavigateToSettings()
     {
         Nav.NavigateTo("/Settings");
     }
-    
-    public static async Task ToggleDrawer()
+
+    private void ToggleDrawer()
     {
-        if (open)
-        {
-            open = false;
-        }
-        else
-        {
-            open = true;
-        }
+        isDrawerOpen = !isDrawerOpen;
     }
-    
+
+    private async Task ChangeThemeAsync()
+    {
+        IsDarkMode = !IsDarkMode ? true : false;
+
+        await LocalStorageService.SetItemAsStringAsync("IsDarkMode", IsDarkMode.ToString());
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
-            await js.InitializeMudBlazorExtensionsAsync();
-        await base.OnAfterRenderAsync(firstRender);
+        if (await LocalStorageService.ContainKeyAsync("IsDarkMode"))
+        {
+            IsDarkMode = Convert.ToBoolean(await LocalStorageService.GetItemAsStringAsync("IsDarkMode"));
+        }
     }
 
     protected override async Task OnInitializedAsync()
     {
         var TeamserverIp = HardHatHubClient.TeamserverIp;
-        HttpClient http = new HttpClient( new HttpClientHandler { ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => true });
+        HttpClient http = new HttpClient(new HttpClientHandler { ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => true });
         HttpResponseMessage response;
         try
         {
             //every 30 seconds using a timer make a Get request to TeamserverIp/swagger to get the status of the teamserver
             var timer = new Timer(async (state) =>
             {
-            try
-            {
-                response = await http.GetAsync($"{TeamserverIp}/swagger");
-                if (response.StatusCode == HttpStatusCode.OK)
+                try
                 {
-                    TeamServerStatus = "Online";
+                    response = await http.GetAsync($"{TeamserverIp}/swagger");
+                    TeamServerStatus = response.StatusCode == HttpStatusCode.OK ? "Online" : "Offline";
                 }
-                else
+                catch (Exception)
                 {
-                    TeamServerStatus = "Offline";
+                    TeamServerStatus = "Unknown";
                 }
-            }
-            catch (Exception)
-            {
-                TeamServerStatus = "Unknown";
-            }
             }, null, 0, 30000);
         }
         catch (Exception)
         {
             TeamServerStatus = "Unknown";
         }
-        
+
         if (Login.SignedInUser == null && Nav.Uri != Nav.BaseUri)
         {
             try
             {
-                Nav.NavigateTo(Nav.BaseUri,true,true);
+                Nav.NavigateTo(Nav.BaseUri, true, true);
             }
             catch (Exception ex)
             {
             }
-
         }
     }
 }


### PR DESCRIPTION
This PR moves the theme toggle functionality out from the `Settings` component to the `MainLayout` one. 

Moreover, it changes the location of the theme toggle button so that it appears on the top nav bar. When the theme is dark, the button uses the primary color:

![image](https://github.com/DragoQCC/HardHatC2/assets/109945717/c353b7af-3ba8-47bf-8033-7af2e5249a97)

However, for the light theme, it uses the default color:

![image](https://github.com/DragoQCC/HardHatC2/assets/109945717/3e077426-e721-46e6-bb52-b9ca23ab0c51)

Also, for aesthetic purposes, I added both the logo and the name of the framework in the top nav bar:

![image](https://github.com/DragoQCC/HardHatC2/assets/109945717/a864c249-3075-48db-943c-9036cc26b182)

Let me know if anything breaks and I will take care of it. (For the file `Settings.razor`, I did some formatting with `Ctrl + K, Ctrl + D`).
 